### PR TITLE
Update GitHub CI

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,14 +5,12 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-
-    - uses: actions/setup-python@v2
-
-    - uses: pre-commit/action@v2.0.3
+    - uses: actions/setup-python@v5
+    - uses: pre-commit/action@v3.0.1
       with:
         extra_args: --from-ref origin/master --to-ref HEAD


### PR DESCRIPTION
Ubuntu 20.04 runners are removed by GitHub, This PR updates the pre-commit CI to a more recent version.